### PR TITLE
feature#182201737-remember information from travel request

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "chai-http": "^4.3.0",
         "cloudinary": "^1.30.0",
         "cloudinary-multer": "^1.0.2",
+        "cookie-parser": "^1.4.6",
         "cors": "^2.8.5",
         "cross-env": "^7.0.3",
         "crypto": "^1.0.1",
@@ -4572,6 +4573,26 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
       "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "dependencies": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -17527,6 +17548,22 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
       "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
+    },
+    "cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "requires": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+          "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
+        }
+      }
     },
     "cookie-signature": {
       "version": "1.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6656,6 +6656,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -19120,6 +19121,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "optional": true
     },
     "ftp": {

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "chai-http": "^4.3.0",
     "cloudinary": "^1.30.0",
     "cloudinary-multer": "^1.0.2",
+    "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
     "cross-env": "^7.0.3",
     "crypto": "^1.0.1",

--- a/src/Documentation/index.doc.js
+++ b/src/Documentation/index.doc.js
@@ -1026,7 +1026,7 @@ const options = {
         },
       },
     },
-    '/api/v1//user/trip/approve/{id}': {
+    '/api/v1/user/trip/approve/{id}': {
       put: {
         tags: ['Manager'],
         description: 'approve trip request',
@@ -1060,7 +1060,7 @@ const options = {
         },
       },
     },
-    '/api/v1//user/trip/reject/{id}': {
+    '/api/v1/user/trip/reject/{id}': {
       put: {
         tags: ['Manager'],
         description: 'reject trip request',

--- a/src/Documentation/index.doc.js
+++ b/src/Documentation/index.doc.js
@@ -270,7 +270,17 @@ const options = {
         },
       },
     },
-
+    '/api/v1/user/remember-info': {
+      put: {
+        tags: ['User'],
+        description: 'Set autofill option',
+        responses: {
+          200: {
+            description: 'success',
+          },
+        },
+      },
+    },
     '/api/v1/accomodation': {
       post: {
         tags: ['Accomodation'],
@@ -714,6 +724,8 @@ const options = {
                 travelReason: 'marketing',
                 accomodationId: 1,
                 roomId: 1,
+                passportName: 'John Doe',
+                passportNumber: '123XYZ4',
               },
             },
           },
@@ -1317,8 +1329,11 @@ const options = {
           accomodationId: {
             type: 'integer',
           },
-          roomId: {
-            type: 'integer',
+          passportName: {
+            type: 'string',
+          },
+          passportNumber: {
+            type: 'string',
           },
         },
       },

--- a/src/app.js
+++ b/src/app.js
@@ -2,6 +2,7 @@ import express from 'express';
 import bodyParser from 'body-parser';
 import cors from 'cors';
 import morgan from 'morgan';
+import cookieParser from 'cookie-parser';
 import globalErrorHandler from './controllers/error';
 import AppError from './utils/appError';
 import allRoutes from './routers/index';
@@ -10,6 +11,7 @@ const app = express();
 
 app.use(cors());
 app.use(morgan('dev'));
+app.use(cookieParser());
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(bodyParser.json());
 

--- a/src/controllers/tripRequestController.js
+++ b/src/controllers/tripRequestController.js
@@ -83,6 +83,16 @@ export const createTripRequest = async (req, res) => {
     trip.accomodation = accomodation;
     trip.roomId = undefined;
     trip.room = room;
+    res.cookie('passportName', req.body.passportName, {
+      secure: true,
+      httpOnly: true,
+      sameSite: 'lax',
+    });
+    res.cookie('passportNumber', req.body.passportNumber, {
+      secure: true,
+      httpOnly: true,
+      sameSite: 'lax',
+    });
     return res.status(201).json({ status: 'success', data: trip });
   } catch (error) {
     return res.status(500).json({ error: error.message });

--- a/src/controllers/tripRequestController.js
+++ b/src/controllers/tripRequestController.js
@@ -68,6 +68,8 @@ export const createTripRequest = async (req, res) => {
       requesterId: req.user.id,
       accomodationId: req.body.accomodationId,
       roomId: req.body.roomId,
+      passportName: req.body.passportName,
+      passportNumber: req.body.passportNumber
     };
     await Room.update(
       {
@@ -582,6 +584,8 @@ export const createMultiTripRequest = async (req, res, next) => {
         requesterId: req.user.id,
         accomodationId: trip_.accomodationId,
         roomId: trip_.roomId,
+        passportName: req.body.passportName,
+        passportNumber: req.body.passportNumber,
       };
       await Room.update(
         {

--- a/src/controllers/users.js
+++ b/src/controllers/users.js
@@ -28,3 +28,18 @@ export const updateRole = (req, res, next) => {
     })
     .catch((error) => res.status(404).json({ error }));
 };
+
+export const updateRememberInfo = async (req, res, next) => {
+  const userEmail = req.user.email;
+  const user = await User.findOne({ where: { email: userEmail } });
+  const response = await User.update(
+    { remember_info: !user.remember_info },
+    { where: { email: userEmail } },
+  );
+  return res
+    .status(200)
+    .json({
+      message: 'remember info option updated successfully',
+      remember_info: user.remember_info,
+    });
+};

--- a/src/controllers/users.js
+++ b/src/controllers/users.js
@@ -36,10 +36,8 @@ export const updateRememberInfo = async (req, res, next) => {
     { remember_info: !user.remember_info },
     { where: { email: userEmail } },
   );
-  return res
-    .status(200)
-    .json({
-      message: 'remember info option updated successfully',
-      remember_info: user.remember_info,
-    });
+  return res.status(200).json({
+    message: 'remember info option updated successfully',
+    remember_info: !user.remember_info,
+  });
 };

--- a/src/database/migrations/20220710172729-add-profile-info-to-request.js
+++ b/src/database/migrations/20220710172729-add-profile-info-to-request.js
@@ -1,0 +1,27 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    try {
+      await queryInterface.addColumn('tripRequests', 'passportName', {
+        type: Sequelize.STRING,
+      });
+      await queryInterface.addColumn('tripRequests', 'passportNumber', {
+        type: Sequelize.STRING,
+      });
+      return Promise.resolve();
+    } catch (e) {
+      return Promise.reject(e);
+    }
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    try {
+      await queryInterface.removeColumn('tripRequests', 'passportName');
+      await queryInterface.removeColumn('tripRequests', 'passportNumber');
+      return Promise.resolve();
+    } catch (e) {
+      return Promise.reject(e);
+    }
+  },
+};

--- a/src/database/migrations/20220710182713-add-remember-info-to-user.js
+++ b/src/database/migrations/20220710182713-add-remember-info-to-user.js
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('users', 'remember_info', {
+      type: Sequelize.BOOLEAN,
+      defaultValue: false,
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeColumn('users', 'remember_info');
+  },
+};

--- a/src/database/models/triprequest.js
+++ b/src/database/models/triprequest.js
@@ -8,7 +8,13 @@ module.exports = (sequelize, DataTypes) => {
       returnDate: DataTypes.STRING,
       travelReason: DataTypes.STRING,
       tripType: DataTypes.STRING,
+<<<<<<< HEAD
       status: DataTypes.ENUM('pending', 'approved', 'rejected'),
+=======
+      status: DataTypes.STRING,
+      passportName: DataTypes.STRING,
+      passportNumber: DataTypes.STRING,
+>>>>>>> remember information from travel request
     },
     {},
   );

--- a/src/database/models/triprequest.js
+++ b/src/database/models/triprequest.js
@@ -8,13 +8,9 @@ module.exports = (sequelize, DataTypes) => {
       returnDate: DataTypes.STRING,
       travelReason: DataTypes.STRING,
       tripType: DataTypes.STRING,
-<<<<<<< HEAD
       status: DataTypes.ENUM('pending', 'approved', 'rejected'),
-=======
-      status: DataTypes.STRING,
       passportName: DataTypes.STRING,
       passportNumber: DataTypes.STRING,
->>>>>>> remember information from travel request
     },
     {},
   );

--- a/src/database/models/user.js
+++ b/src/database/models/user.js
@@ -54,6 +54,10 @@ export default (sequelize, DataTypes) => {
         'travel team member',
         'accommodation supplier',
       ),
+      remember_info: {
+        type: DataTypes.BOOLEAN,
+        defaultValue: false,
+      },
     },
     {
       sequelize,

--- a/src/helpers/validation_schema.js
+++ b/src/helpers/validation_schema.js
@@ -56,13 +56,15 @@ export const updateProfileSchema = Joi.object({
 });
 
 export const tripRequestSchema = Joi.object({
-  leavingFrom: Joi.string().required(),
+  leavingFrom: Joi.string().allow(''),
   goingTo: Joi.number().required(),
   travelDate: Joi.string().required(),
   returnDate: Joi.string(),
   travelReason: Joi.string().required(),
   accomodationId: Joi.number().required(),
   roomId: Joi.number().required(),
+  passportName: Joi.string().allow(''),
+  passportNumber: Joi.string().allow(''),
 });
 export const tripRequestUpdateSchema = Joi.object({
   leavingFrom: Joi.string().required(),

--- a/src/middlewares/checkRememberInfo.js
+++ b/src/middlewares/checkRememberInfo.js
@@ -1,0 +1,18 @@
+import db from '../database/models/index';
+const users = db['users'];
+
+export const checkRememberInfo = async (req, res, next) => {
+  const userId = req.user.id;
+  const requester = await users.findOne({ where: { id: userId } });
+
+  if (requester.remember_info === true && req.cookies) {
+    console.log(req.cookies);
+    if (req.body.passportName === '') {
+      req.body.passportName = req.cookies.passportName;
+    }
+    if (req.body.passportNumber === '') {
+      req.body.passportNumber = req.cookies.passportNumber;
+    }
+  }
+  next();
+};

--- a/src/middlewares/checkRememberInfo.js
+++ b/src/middlewares/checkRememberInfo.js
@@ -6,7 +6,6 @@ export const checkRememberInfo = async (req, res, next) => {
   const requester = await users.findOne({ where: { id: userId } });
 
   if (requester.remember_info === true && req.cookies) {
-    console.log(req.cookies);
     if (req.body.passportName === '') {
       req.body.passportName = req.cookies.passportName;
     }

--- a/src/middlewares/checkRememberInfo.js
+++ b/src/middlewares/checkRememberInfo.js
@@ -5,10 +5,10 @@ export const checkRememberInfo = async (req, res, next) => {
   const userId = req.user.id;
   const requester = await users.findOne({ where: { id: userId } });
   if (requester.remember_info === true && req.cookies) {
-    if (req.body.passportName === '') {
+    if (!req.body.passportName || req.body.passportName === '') {
       req.body.passportName = req.cookies.passportName;
     }
-    if (req.body.passportNumber === '') {
+    if (!req.body.passportNumber || req.body.passportNumber === '') {
       req.body.passportNumber = req.cookies.passportNumber;
     }
   }

--- a/src/middlewares/checkRememberInfo.js
+++ b/src/middlewares/checkRememberInfo.js
@@ -4,7 +4,6 @@ const users = db['users'];
 export const checkRememberInfo = async (req, res, next) => {
   const userId = req.user.id;
   const requester = await users.findOne({ where: { id: userId } });
-
   if (requester.remember_info === true && req.cookies) {
     if (req.body.passportName === '') {
       req.body.passportName = req.cookies.passportName;

--- a/src/routers/api/tripRequest.routes.js
+++ b/src/routers/api/tripRequest.routes.js
@@ -16,12 +16,14 @@ import {
   getComments,
   deleteComment,
 } from '../../controllers/tripRequest.comments';
+import { checkRememberInfo } from '../../middlewares/checkRememberInfo';
 import { protect } from '../../controllers/authentication';
 
 const router = express.Router();
 
 router.post('', protect, createTripRequest);
 router.get('/most-travelled-destinations', protect, mostTavelledDestinations);
+router.post('', protect, checkRememberInfo, createTripRequest);
 router.post('/multi', protect, createMultiTripRequest);
 router.get('/get', protect, getAllTripRequest);
 router.get('/get/:id', protect, getSingleTripRequest);

--- a/src/routers/api/tripRequest.routes.js
+++ b/src/routers/api/tripRequest.routes.js
@@ -21,9 +21,8 @@ import { protect } from '../../controllers/authentication';
 
 const router = express.Router();
 
-router.post('', protect, createTripRequest);
-router.get('/most-travelled-destinations', protect, mostTavelledDestinations);
 router.post('', protect, checkRememberInfo, createTripRequest);
+router.get('/most-travelled-destinations', protect, mostTavelledDestinations);
 router.post('/multi', protect, createMultiTripRequest);
 router.get('/get', protect, getAllTripRequest);
 router.get('/get/:id', protect, getSingleTripRequest);

--- a/src/routers/api/users.js
+++ b/src/routers/api/users.js
@@ -10,7 +10,7 @@ import {
   updateUserProfile,
   getAllUsers,
 } from '../../controllers/userController';
-import { updateRole } from '../../controllers/users';
+import { updateRole, updateRememberInfo } from '../../controllers/users';
 import isValidRole from '../../middlewares/isValidRole';
 import isAdmin from '../../middlewares/isAdmin';
 import multer from 'multer';
@@ -58,5 +58,6 @@ userRouter.patch(
 userRouter.get('/', getAllUsers);
 userRouter.get('/:id', protect, getUserData);
 userRouter.put('/roles', isAdmin, isValidRole, updateRole);
+userRouter.put('/remember-info', protect, updateRememberInfo);
 
 export default userRouter;

--- a/test/comment.test.js
+++ b/test/comment.test.js
@@ -122,7 +122,6 @@ describe('comment on trip requests', () => {
       .delete('/api/v1/user/trip/comments/24/delete')
       .set('authorization', `Bearer ${token}`)
       .end((err, res) => {
-        console.log(res.body);
         expect(res.status).to.equal(200);
         expect(res.body)
           .to.have.property('message')

--- a/test/room.test.js
+++ b/test/room.test.js
@@ -68,6 +68,20 @@ describe('POST api/v1/rooms/accomodationId', () => {
       .send(room)
       .end((err, res) => {
         expect(res.status).to.be.equal(201);
+      });
+    api
+      .post('/api/v1/rooms/' + accomodationId)
+      .set('Authorization', `Bearer ${newToken}`)
+      .send(room)
+      .end((err, res) => {
+        expect(res.status).to.be.equal(201);
+      });
+    api
+      .post('/api/v1/rooms/' + accomodationId)
+      .set('Authorization', `Bearer ${newToken}`)
+      .send(room)
+      .end((err, res) => {
+        expect(res.status).to.be.equal(201);
         done();
       });
   });

--- a/test/room.test.js
+++ b/test/room.test.js
@@ -52,6 +52,22 @@ describe('POST api/v1/rooms/accomodationId', () => {
       .send(room)
       .end((err, res) => {
         expect(res.status).to.be.equal(201);
+      });
+
+    api
+      .post('/api/v1/rooms/' + accomodationId)
+      .set('Authorization', `Bearer ${newToken}`)
+      .send(room)
+      .end((err, res) => {
+        expect(res.status).to.be.equal(201);
+      });
+
+    api
+      .post('/api/v1/rooms/' + accomodationId)
+      .set('Authorization', `Bearer ${newToken}`)
+      .send(room)
+      .end((err, res) => {
+        expect(res.status).to.be.equal(201);
         done();
       });
   });

--- a/test/tripRequest.test.js
+++ b/test/tripRequest.test.js
@@ -646,7 +646,8 @@ describe('Get profile information from travel request', () => {
       travelDate: '2022-6-20',
       returnDate: '2022-6-26',
       travelReason: 'CHOGM',
-      accomodationId: 1,
+      accomodationId: 2,
+      roomId: 4,
       passportName: 'John Doe',
       passportNumber: '123XYZ4',
     };
@@ -657,7 +658,8 @@ describe('Get profile information from travel request', () => {
       travelDate: '2024-6-20',
       returnDate: '2024-6-26',
       travelReason: 'Something else',
-      accomodationId: 1,
+      accomodationId: 2,
+      roomId: 5,
       passportName: '',
       passportNumber: '',
     };
@@ -672,6 +674,7 @@ describe('Get profile information from travel request', () => {
           .set('Cookie', 'passportNumber=123XYZ4;passportName=John Doe')
           .send(request_two)
           .end((err, res) => {
+            console.log(res);
             res.should.have.status(201);
             res.body.should.have.property('data');
             res.body.data.should.have.property('passportName');

--- a/test/tripRequest.test.js
+++ b/test/tripRequest.test.js
@@ -674,7 +674,6 @@ describe('Get profile information from travel request', () => {
           .set('Cookie', 'passportNumber=123XYZ4;passportName=John Doe')
           .send(request_two)
           .end((err, res) => {
-            console.log(res);
             res.should.have.status(201);
             res.body.should.have.property('data');
             res.body.data.should.have.property('passportName');

--- a/test/tripRequest.test.js
+++ b/test/tripRequest.test.js
@@ -605,3 +605,83 @@ describe('Reject Trip Request', () => {
       });
   });
 });
+
+describe('Get profile information from travel request', () => {
+  let token;
+  it('should update the remember info option', (done) => {
+    const user = {
+      firstName: 'john',
+      lastName: 'doe',
+      username: 'jdoe',
+      email: 'jdoe@gmail.com',
+      password: 'teste',
+      repeat_password: 'teste',
+      phoneNumber: '0788800012',
+      role: 'requester',
+    };
+
+    api
+      .post('/api/v1/user/auth/signup')
+      .send(user)
+      .end((err, res) => {
+        token = res.body.token;
+        api
+          .put('/api/v1/user/remember-info')
+          .set('Authorization', `Bearer ${token}`)
+          .end((err, res) => {
+            res.should.have.status(200);
+            res.body.should.have.property('message');
+            expect(res.body.message).to.equal(
+              'remember info option updated successfully',
+            );
+            done();
+          });
+      });
+  });
+
+  it('should get the information from request', (done) => {
+    const request_one = {
+      leavingFrom: 'kigali',
+      goingTo: 1,
+      travelDate: '2022-6-20',
+      returnDate: '2022-6-26',
+      travelReason: 'CHOGM',
+      accomodationId: 1,
+      passportName: 'John Doe',
+      passportNumber: '123XYZ4',
+    };
+
+    const request_two = {
+      leavingFrom: '',
+      goingTo: 1,
+      travelDate: '2024-6-20',
+      returnDate: '2024-6-26',
+      travelReason: 'Something else',
+      accomodationId: 1,
+      passportName: '',
+      passportNumber: '',
+    };
+    api
+      .post('/api/v1/user/trip')
+      .set('Authorization', `Bearer ${token}`)
+      .send(request_one)
+      .end((err, res) => {
+        api
+          .post('/api/v1/user/trip')
+          .set('Authorization', `Bearer ${token}`)
+          .send(request_two)
+          .end((err, res) => {
+            res.should.have.status(201);
+            res.body.should.have.property('data');
+            res.body.data.should.have.property('leavingFrom');
+            res.body.data.should.have.property('passportName');
+            res.body.data.should.have.property('passportNumber');
+            expect(res.body.status).to.equal('success');
+            expect(res.body.data.leavingFrom).to.equal('kigali');
+            expect(res.body.data.passportName).to.equal('John Doe');
+            expect(res.body.data.passportNumber).to.equal('123XYZ4');
+            done();
+          });
+      });
+  });
+});

--- a/test/tripRequest.test.js
+++ b/test/tripRequest.test.js
@@ -631,6 +631,8 @@ describe('Get profile information from travel request', () => {
           .end((err, res) => {
             res.should.have.status(200);
             res.body.should.have.property('message');
+            res.body.should.have.property('remember_info');
+            expect(res.body.remember_info).to.equal(true);
             expect(res.body.message).to.equal(
               'remember info option updated successfully',
             );
@@ -681,6 +683,65 @@ describe('Get profile information from travel request', () => {
             expect(res.body.status).to.equal('success');
             expect(res.body.data.passportName).to.equal('John Doe');
             expect(res.body.data.passportNumber).to.equal('123XYZ4');
+            done();
+          });
+      });
+  });
+
+  it('should not get the information from request', (done) => {
+    const request_one = {
+      leavingFrom: 'kigali',
+      goingTo: 1,
+      travelDate: '2022-6-20',
+      returnDate: '2022-6-26',
+      travelReason: 'CHOGM',
+      accomodationId: 2,
+      roomId: 6,
+      passportName: 'John Doe',
+      passportNumber: '123XYZ4',
+    };
+
+    const request_two = {
+      leavingFrom: 'kigali',
+      goingTo: 1,
+      travelDate: '2024-6-20',
+      returnDate: '2024-6-26',
+      travelReason: 'Something else',
+      accomodationId: 2,
+      roomId: 7,
+      passportName: '',
+      passportNumber: '',
+    };
+    api
+      .put('/api/v1/user/remember-info')
+      .set('Authorization', `Bearer ${token}`)
+      .end((err, res) => {
+        res.should.have.status(200);
+        res.body.should.have.property('message');
+        res.body.should.have.property('remember_info');
+        expect(res.body.remember_info).to.equal(false);
+        expect(res.body.message).to.equal(
+          'remember info option updated successfully',
+        );
+      });
+    api
+      .post('/api/v1/user/trip')
+      .set('Authorization', `Bearer ${token}`)
+      .send(request_one)
+      .end((err, res) => {
+        api
+          .post('/api/v1/user/trip')
+          .set('Authorization', `Bearer ${token}`)
+          .set('Cookie', 'passportNumber=123XYZ4;passportName=John Doe')
+          .send(request_two)
+          .end((err, res) => {
+            res.should.have.status(201);
+            res.body.should.have.property('data');
+            res.body.data.should.have.property('passportName');
+            res.body.data.should.have.property('passportNumber');
+            expect(res.body.status).to.equal('success');
+            expect(res.body.data.passportName).to.equal('');
+            expect(res.body.data.passportNumber).to.equal('');
             done();
           });
       });

--- a/test/tripRequest.test.js
+++ b/test/tripRequest.test.js
@@ -652,7 +652,7 @@ describe('Get profile information from travel request', () => {
     };
 
     const request_two = {
-      leavingFrom: '',
+      leavingFrom: 'kigali',
       goingTo: 1,
       travelDate: '2024-6-20',
       returnDate: '2024-6-26',
@@ -669,15 +669,14 @@ describe('Get profile information from travel request', () => {
         api
           .post('/api/v1/user/trip')
           .set('Authorization', `Bearer ${token}`)
+          .set('Cookie', 'passportNumber=123XYZ4;passportName=John Doe')
           .send(request_two)
           .end((err, res) => {
             res.should.have.status(201);
             res.body.should.have.property('data');
-            res.body.data.should.have.property('leavingFrom');
             res.body.data.should.have.property('passportName');
             res.body.data.should.have.property('passportNumber');
             expect(res.body.status).to.equal('success');
-            expect(res.body.data.leavingFrom).to.equal('kigali');
             expect(res.body.data.passportName).to.equal('John Doe');
             expect(res.body.data.passportNumber).to.equal('123XYZ4');
             done();


### PR DESCRIPTION
#### What does this PR do?
 - update remember info option
 - remember info from travel request
 - use information from previous requests into new requests
#### Description of Task to be completed?
 - add remember_info option field to the user model and migration
 - update remember_info option to true or false
#### How should this be manually tested?
 - clone this repository
 - checkout to this branch `ft-remember-info-from-request-182201737`
 - run `npm install` to install dependencies
 - run migrations and seed using `npm run migrate` and `npm run seed`
 - run `npm run start:dev` to start the development server 
 - use swagger on `localhost:4000/api/v1/docs`
 - use the `/api/v1/user/remember-info` endpoint to update remember info field
 - I. create first travel request
 - ll. create second request without adding some fields like , `passportName`, `passportNumber` and it will be added automatically from the cookies
#### What are the relevant pivotal tracker stories?
 - https://www.pivotaltracker.com/n/projects/2569105/stories/182201737
#### Screenshots(If appropriate)



